### PR TITLE
Potential fix for code scanning alert no. 1: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -37,4 +37,3 @@ jobs:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}


### PR DESCRIPTION
Potential fix for [https://github.com/Sumit-SC/ping/security/code-scanning/1](https://github.com/Sumit-SC/ping/security/code-scanning/1)

The correct fix is to stop passing the entire secrets object and only pass the specific secret(s) needed by the action. In this file, the `Update response time` step already supplies `GH_PAT`, so `SECRETS_CONTEXT` should be removed entirely.

Best single fix (no functionality change expected):
- Edit `.github/workflows/response-time.yml`
- In the `jobs.release.steps` section, under step `- name: Update response time` → `env:`
- Remove the line:
  - `SECRETS_CONTEXT: ${{ toJson(secrets) }}`
- Keep `GH_PAT: ${{ secrets.GH_PAT || github.token }}` unchanged.

No new imports, methods, or definitions are needed in a GitHub Actions YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
